### PR TITLE
fixed conda env; added function support back

### DIFF
--- a/blockly-extensions.yml
+++ b/blockly-extensions.yml
@@ -5,8 +5,10 @@ channels:
   - defaults
 dependencies:
   - python=3.7
-  - xeus-python
-  - jupyterlab=1.2.6
+  - xeus-python=0.7
+  - jupyter_client=6.1
+  - jupyter_core=4.6
+  - jupyterlab=1.2
   - pip
   - pandas
   - plotly

--- a/src/Toolbox.fs
+++ b/src/Toolbox.fs
@@ -54,20 +54,22 @@ let deleteDefinitions : unit = jsNative
 let deleteFunctions : unit = jsNative
 
 //Prevent Blockly from prepending variable definitions for us 
-// 'id' is too heavy handed - we want imports but not definitions
-// blockly?Python?finish <- id
-// This allows imports but not definitions //TODO: code gen for functions seems to be broken, maybe here?
+// This allows imports and function definitions but not variable definitions; functions are identified using the language keyword
 blockly?Python?finish <- System.Func<string,string>(fun code ->
   let imports = ResizeArray<string>()
+  let functions = ResizeArray<string>()
   for name in JS.Constructors.Object.keys( blockly?Python?definitions_ ) do
     let ( definitions : obj ) =  blockly?Python?definitions_
     let (def : string) = definitions.[ name ] |> string
     if def.Contains("import") then
       imports.Add(def)
+    //auto functions (functions defined for default blocks) begin with "def"; user-defined functions (created via FUNCTIONS category) begin with "#" 
+    if def.StartsWith("def ") ||  def.StartsWith("# ") then 
+      functions.Add(def)
   deleteDefinitions
   deleteFunctions
   blockly?Python?variableDB_?reset()
-  (imports |> String.concat "\n")  + "\n\n" + code)
+  (imports |> String.concat "\n")  + (functions |> String.concat "\n")  + "\n\n" + code)
 
 /// Encode the current Blockly workspace as an XML string
 let encodeWorkspace() =
@@ -1365,7 +1367,7 @@ let toolbox =
     </category>
     <sep></sep>
     <category name="VARIABLES" colour="%{BKY_VARIABLES_HUE}" custom="VARIABLE"></category>
-    <!-- <category name="FUNCTIONS" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category> -->
+    <category name="FUNCTIONS" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
   </xml>"""
 
 


### PR DESCRIPTION
Notebook sync creates a usability issue for user defined functions under the following scenario:

- Notebook sync is on
- User defines function in cell with blocks to code
- User selects new cell
- Notebook sync clears all workspace blocks **including the function definition block**
- Removal of function definition block causes user defined function to disappear from FUNCTIONS menu
- User defined function appears in trash

Part of the usability problem is that user defined functions behave differently than user defined variables.

Options to resolve are:

- Rewrite blockly to handle user defined functions the same way as user defined variables
- Never remove user defined functions through notebook sync (this will cause them to accumulate in workspace)
- Allow functions  to disappear from cell to cell (**current solution**)